### PR TITLE
Use [E]lement since we don't support IE8 any more

### DIFF
--- a/app/templates/files/component.mustache.html
+++ b/app/templates/files/component.mustache.html
@@ -8,4 +8,4 @@
   Try to have one enclosing tag around your component and add the components
   name as a class to it.
 -->
-<div <%= componentName %>></div>
+<<%= componentName %>></<%= componentName %>>


### PR DESCRIPTION
IE8 has issues with non-existing tags. One workaround is to use attributes on a <div> instead. We no longer need to do this, since we no longer support IE8.
